### PR TITLE
Add JiraRetriever implementation

### DIFF
--- a/retrievers/jira_retriever.py
+++ b/retrievers/jira_retriever.py
@@ -1,14 +1,66 @@
-"""Retriever for existing roadmap ideas from JIRA."""
+"""Retrieve issues from a JIRA project via the REST API."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import requests
 
 
 class JiraRetriever:
-    """Placeholder JIRA retriever."""
+    """Simple JIRA REST API client."""
 
     def __init__(self, url: str, username: str, token: str) -> None:
-        self.url = url
-        self.username = username
-        self.token = token
+        """Store authentication details for API calls."""
 
-    def fetch_issues(self) -> list:
-        """Return JIRA issues representing roadmap ideas."""
-        return []
+        self.base_url = url.rstrip("/")
+        self.auth: Tuple[str, str] = (username, token)
+
+    def fetch_issues(self, project_key: str, max_results: int = 50) -> List[Dict[str, Optional[str]]]:
+        """Return issues for the given project.
+
+        Parameters
+        ----------
+        project_key:
+            Key of the JIRA project.
+        max_results:
+            Number of issues to request per page.
+        """
+
+        search_url = f"{self.base_url}/rest/api/2/search"
+
+        start_at = 0
+        issues: List[Dict[str, Optional[str]]] = []
+
+        while True:
+            params = {
+                "jql": f"project={project_key}",
+                "startAt": start_at,
+                "maxResults": max_results,
+                "fields": "summary,description,status,labels",
+            }
+
+            response = requests.get(search_url, params=params, auth=self.auth, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            for issue in data.get("issues", []):
+                fields = issue.get("fields", {})
+                issues.append(
+                    {
+                        "key": issue.get("key"),
+                        "summary": fields.get("summary"),
+                        "description": fields.get("description"),
+                        "status": (fields.get("status") or {}).get("name"),
+                        "labels": fields.get("labels", []),
+                    }
+                )
+
+            retrieved = start_at + data.get("maxResults", 0)
+            total = data.get("total", 0)
+            if retrieved >= total:
+                break
+            start_at = retrieved
+
+        return issues
+


### PR DESCRIPTION
## Summary
- implement JiraRetriever for downloading project issues via JIRA REST API
- add pagination handling

## Testing
- `python -m py_compile retrievers/jira_retriever.py`

------
https://chatgpt.com/codex/tasks/task_b_685e3e4ff4088330807a0e555bff2587