### PR TITLE
Implement Jira roadmap retriever

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+JIRA_URL=https://your-instance.atlassian.net
+JIRA_PROJECT_KEY=PROJ
+JIRA_AUTH_TOKEN=base64encodedtoken

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Exports ideas as Markdown, JSON, or into JIRA.
 - JIRA REST API
 - Streamlit (optional frontend)
 
+### Configuration
+Create a `.env` file in the project root based on `.env.example` and set:
+
+- `JIRA_URL` – Base URL of your JIRA instance
+- `JIRA_PROJECT_KEY` – Project key to fetch issues from
+- `JIRA_AUTH_TOKEN` – Base64 token used for Basic Auth
+
 ---
 
 ## 🚧 Milestone Plan (MVP)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ atlassian-python-api>=3.41
 requests>=2.31
 streamlit>=1.28
 beautifulsoup4>=4.12
+pydantic>=2.0
+tenacity>=8.0
+python-dotenv>=1.0

--- a/retrievers/jira_retriever.py
+++ b/retrievers/jira_retriever.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 
+import os
+
 import requests
+from pydantic import BaseModel
+from tenacity import retry, stop_after_attempt, wait_exponential
+from dotenv import load_dotenv
 
 
 class JiraRetriever:
@@ -63,4 +68,79 @@ class JiraRetriever:
             start_at = retrieved
 
         return issues
+
+
+class JiraIssue(BaseModel):
+    """Representation of a JIRA issue used by ``get_roadmap_ideas``."""
+
+    key: str
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    roadmap: Optional[str] = None
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=5), reraise=True)
+def _get(url: str, params: Dict[str, str], token: str) -> Dict:
+    """Issue a GET request with retries."""
+
+    headers = {
+        "Authorization": f"Basic {token}",
+        "Accept": "application/json",
+    }
+    response = requests.get(url, params=params, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_roadmap_ideas(
+    jira_url: Optional[str] = None,
+    project_key: Optional[str] = None,
+    auth_token: Optional[str] = None,
+) -> List[Dict]:
+    """Fetch all issues from ``project_key`` and return minimal idea dicts."""
+
+    load_dotenv()
+    jira_url = jira_url or os.getenv("JIRA_URL")
+    project_key = project_key or os.getenv("JIRA_PROJECT_KEY")
+    auth_token = auth_token or os.getenv("JIRA_AUTH_TOKEN")
+
+    if not jira_url or not project_key or not auth_token:
+        raise ValueError("Missing JIRA_URL, JIRA_PROJECT_KEY or JIRA_AUTH_TOKEN")
+
+    search_url = jira_url.rstrip("/") + "/rest/api/2/search"
+
+    start_at = 0
+    max_results = 50
+    issues: List[JiraIssue] = []
+
+    while True:
+        params = {
+            "jql": f"project={project_key}",
+            "startAt": start_at,
+            "maxResults": max_results,
+            "fields": "summary,description,status,roadmap",
+        }
+
+        data = _get(search_url, params, auth_token)
+
+        for issue in data.get("issues", []):
+            fields = issue.get("fields", {})
+            issues.append(
+                JiraIssue(
+                    key=issue.get("key"),
+                    summary=fields.get("summary"),
+                    description=fields.get("description"),
+                    status=(fields.get("status") or {}).get("name"),
+                    roadmap=fields.get("roadmap"),
+                )
+            )
+
+        retrieved = start_at + data.get("maxResults", 0)
+        total = data.get("total", 0)
+        if retrieved >= total:
+            break
+        start_at = retrieved
+
+    return [issue.dict() for issue in issues]
 

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,8 @@ setup(
         "requests>=2.31",
         "streamlit>=1.28",
         "beautifulsoup4>=4.12",
+        "pydantic>=2.0",
+        "tenacity>=8.0",
+        "python-dotenv>=1.0",
     ],
 )


### PR DESCRIPTION
## Summary
- expand requirements with pydantic, tenacity and dotenv
- add dotenv config example
- document environment variables in README
- implement Jira roadmap retrieval with retry and pydantic model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685e4411b70483308e74f465dd770a82