### PR TITLE
Implement in-memory deduplication checker

### DIFF
--- a/deduplication/checker.py
+++ b/deduplication/checker.py
@@ -1,12 +1,34 @@
 """Deduplication layer for idea checking."""
 
 
+import hashlib
+from typing import Dict, Set
+
+
 class DeduplicationChecker:
-    """Placeholder deduplication checker."""
+    """Simple in-memory deduplication checker."""
 
     def __init__(self) -> None:
-        pass
+        """Initialize storage for seen idea hashes."""
+        self._seen_hashes: Set[str] = set()
 
-    def is_duplicate(self, idea: str) -> bool:
-        """Determine whether an idea already exists."""
-        return False
+    def _hash_title(self, idea: Dict | str) -> str:
+        """Return a stable hash for the given idea's title."""
+
+        if isinstance(idea, dict):
+            title = idea.get("title") or idea.get("summary") or str(idea)
+        else:
+            title = str(idea)
+
+        normalized = title.strip().lower()
+        return hashlib.sha1(normalized.encode("utf-8")).hexdigest()
+
+    def add(self, idea: Dict | str) -> None:
+        """Add an idea to the seen set."""
+
+        self._seen_hashes.add(self._hash_title(idea))
+
+    def is_duplicate(self, idea: Dict | str) -> bool:
+        """Return ``True`` if the idea title has been seen before."""
+
+        return self._hash_title(idea) in self._seen_hashes

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -62,8 +62,13 @@ class AgentOrchestrator:
         print("\n== Running reasoning engine ==")
         ideas = self.reasoning.analyze(roadmap_docs, jira_issues)
 
-        # Placeholder: integrate deduplication layer here
-        # ideas = [i for i in ideas if not self.dedup_checker.is_duplicate(i)]
+        # Filter out ideas we've already seen
+        deduped: List[dict] = []
+        for idea in ideas:
+            if not self.dedup_checker.is_duplicate(idea):
+                deduped.append(idea)
+                self.dedup_checker.add(idea)
+        ideas = deduped
 
         if not ideas:
             print("No ideas generated")


### PR DESCRIPTION
## Summary
- implement a simple in-memory deduplication mechanism
- check for duplicates and update the cache when orchestrating

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e5b75f59883308ef7b7f082624919