### PR TITLE
Improve idea composition and orchestrator

### DIFF
--- a/ideas/composer.py
+++ b/ideas/composer.py
@@ -1,12 +1,66 @@
 """Idea composition module."""
 
 
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List
+
+
 class IdeaComposer:
     """Creates structured idea proposals."""
 
     def __init__(self) -> None:
         pass
 
-    def compose(self, ideas: list) -> list:
-        """Return formatted ideas with metadata."""
-        return []
+    def compose(self, ideas: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return formatted ideas with metadata.
+
+        Parameters
+        ----------
+        ideas:
+            Raw idea dictionaries typically returned by the reasoning layer.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            Each idea enriched with ``id`` and ``markdown`` fields as well as a
+            ``metadata`` dictionary.
+        """
+
+        formatted: List[Dict[str, Any]] = []
+
+        for raw in ideas:
+            if not isinstance(raw, dict):
+                # Skip invalid items but continue processing
+                continue
+
+            title = raw.get("title") or raw.get("summary") or "Untitled idea"
+            problem = raw.get("problem", "")
+            proposal = raw.get("proposal", "")
+            business_value = raw.get("business_value", "")
+            confidence = raw.get("confidence_score")
+
+            markdown = (
+                f"* **{title}**\n"
+                f"  * Problem: {problem}\n"
+                f"  * Proposal: {proposal}\n"
+                f"  * Business Value: {business_value}\n"
+                f"  * Confidence: {confidence}"
+            )
+
+            structured = {
+                "id": str(uuid.uuid4()),
+                "title": title,
+                "markdown": markdown,
+                "metadata": {
+                    "problem": problem,
+                    "proposal": proposal,
+                    "business_value": business_value,
+                    "confidence_score": confidence,
+                },
+            }
+
+            formatted.append(structured)
+
+        return formatted


### PR DESCRIPTION
## Summary
- enrich `IdeaComposer.compose` to create Markdown summaries and metadata
- hook new composer into `AgentOrchestrator.run_agent`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685e5b83eea88330900eed042327a3fb