### PR TITLE
Improve README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,35 @@ Its purpose is to suggest **novel, feasible, and impactful ideas**, identify **s
    python orchestrator.py
    ```
 
+4. Run the test-suite to verify your setup:
+   ```bash
+   pytest -q
+   ```
+
 OpenAI API calls require a valid `OPENAI_API_KEY` in your environment.
+
+
+## 🏃 Usage
+
+Running the orchestrator will crawl the roadmap URL, fetch JIRA issues and
+write generated ideas to the `output/` directory:
+
+```bash
+python orchestrator.py
+```
+
+The resulting `ideas.json` and `ideas.md` files contain structured suggestions
+that you can further review or import into your tooling.
+
+## ✔️ Running Tests
+
+Unit tests cover all modules and can be executed with `pytest` from the project
+root. This is useful to confirm that optional environment variables are set
+correctly and that the basic workflow still works:
+
+```bash
+pytest -q
+```
 
 
 ## 📦 Architecture Overview


### PR DESCRIPTION
## Summary
- add steps on running tests
- document how to run the orchestrator
- add Usage and Running Tests sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e6948e03483309e909d28ca82564d