### PR TITLE
Support JIRA_JQL in Jira retriever

### DIFF
--- a/retrievers/jira_retriever.py
+++ b/retrievers/jira_retriever.py
@@ -1,40 +1,39 @@
 from __future__ import annotations
 
+"""Retrieve JIRA issues for the orchestrator."""
+
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
-from dotenv import load_dotenv
 import requests
-from tenacity import retry, stop_after_attempt, wait_exponential
+from dotenv import load_dotenv
 from pydantic import BaseModel
+from tenacity import retry, stop_after_attempt, wait_exponential
 
-# 1) Načtení .env
-load_dotenv()  # pip install python-dotenv
+# Load environment variables from .env file
+load_dotenv()
 
 JIRA_URL = os.getenv("JIRA_URL")
 JIRA_PROJECT_KEY = os.getenv("JIRA_PROJECT_KEY")
 JIRA_AUTH_TOKEN = os.getenv("JIRA_AUTH_TOKEN")
+# Optional JQL query overriding the project key
+JIRA_JQL = os.getenv("JIRA_JQL")
 
-if not (JIRA_URL and JIRA_PROJECT_KEY and JIRA_AUTH_TOKEN):
-    raise EnvironmentError(
-        "Chybí některé JIRA proměnné v prostředí: "
-        "JIRA_URL, JIRA_PROJECT_KEY nebo JIRA_AUTH_TOKEN"
-    )
+if not JIRA_URL or not JIRA_AUTH_TOKEN:
+    raise EnvironmentError("JIRA_URL and JIRA_AUTH_TOKEN must be set")
 
-# 2) Helper s retry
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=1, max=5),
-    reraise=True
-)
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=5), reraise=True)
 def _jira_get(
     endpoint: str,
     params: dict[str, object],
+    auth_token: str | None = None,
     *,
-    jira_url: str = JIRA_URL,
-    auth_token: str = JIRA_AUTH_TOKEN,
+    jira_url: str | None = None,
 ) -> dict:
-    """Spustí GET na zadaný JIRA endpoint s retry logikou."""
+    """Low level GET helper with retry."""
+
+    jira_url = jira_url or JIRA_URL
+    auth_token = auth_token or JIRA_AUTH_TOKEN
 
     url = f"{jira_url.rstrip('/')}/{endpoint.lstrip('/')}"
     headers = {
@@ -45,7 +44,6 @@ def _jira_get(
     resp.raise_for_status()
     return resp.json()
 
-# 3) Pydantic model pro Issue
 class JiraIssue(BaseModel):
     key: str
     summary: Optional[str]
@@ -53,55 +51,8 @@ class JiraIssue(BaseModel):
     status: Optional[str]
     labels: Optional[List[str]]
 
-
-def fetch_all_issues(
-    project_key: str = JIRA_PROJECT_KEY,
-    max_results: int = 50,
-) -> List[JiraIssue]:
-    """
-    Načte všechny issue z projektu, stránku po stránce.
-    """
-    endpoint = "rest/api/2/search"
-    start_at = 0
-    issues: List[JiraIssue] = []
-
-    while True:
-        params = {
-            "jql": f"project={project_key}",
-            "startAt": start_at,
-            "maxResults": max_results,
-            "fields": "summary,description,status,labels",
-        }
-        data = _jira_get(endpoint, params)
-
-        for raw in data.get("issues", []):
-            f = raw.get("fields", {})
-            issues.append(
-                JiraIssue(
-                    key=raw.get("key"),
-                    summary=f.get("summary"),
-                    description=f.get("description"),
-                    status=(f.get("status") or {}).get("name"),
-                    labels=f.get("labels", []),
-                )
-            )
-
-        total = data.get("total", 0)
-        start_at += max_results
-        if start_at >= total:
-            break
-
-    return issues
-
-
-def _fetch_issues(
-    jira_url: str,
-    project_key: str,
-    auth_token: str,
-    jql: str,
-    max_results: int,
-) -> List[JiraIssue]:
-    """Internal helper used by :func:`get_roadmap_ideas`."""
+def _fetch_issues(jira_url: str, auth_token: str, jql: str, max_results: int) -> List[JiraIssue]:
+    """Fetch issues from JIRA using the given JQL query."""
 
     endpoint = "rest/api/2/search"
     start_at = 0
@@ -114,7 +65,7 @@ def _fetch_issues(
             "maxResults": max_results,
             "fields": "summary,description,status,labels",
         }
-        data = _jira_get(endpoint, params, jira_url=jira_url, auth_token=auth_token)
+        data = _jira_get(endpoint, params, auth_token, jira_url=jira_url)
 
         for raw in data.get("issues", []):
             f = raw.get("fields", {})
@@ -135,6 +86,13 @@ def _fetch_issues(
 
     return issues
 
+def fetch_all_issues(project_key: str = JIRA_PROJECT_KEY, max_results: int = 50) -> List[JiraIssue]:
+    """Compatibility wrapper returning all issues for a project."""
+
+    if not project_key:
+        raise ValueError("Project key must be provided when JIRA_JQL is not used")
+    jql = f"project={project_key}"
+    return _fetch_issues(JIRA_URL, JIRA_AUTH_TOKEN, jql, max_results)
 
 def get_roadmap_ideas(
     jira_url: str | None = None,
@@ -143,23 +101,23 @@ def get_roadmap_ideas(
     jql: str | None = None,
     max_results: int = 50,
 ) -> List[dict]:
-    """Return roadmap ideas from JIRA as list of dicts."""
+    """Return roadmap ideas from JIRA as list of plain dicts."""
 
-    jira_url = jira_url or os.getenv("JIRA_URL")
-    project_key = project_key or os.getenv("JIRA_PROJECT_KEY")
-    auth_token = auth_token or os.getenv("JIRA_AUTH_TOKEN")
+    jira_url = jira_url or JIRA_URL
+    auth_token = auth_token or JIRA_AUTH_TOKEN
+    project_key = project_key or JIRA_PROJECT_KEY
+    jql = jql or JIRA_JQL or (f"project={project_key}" if project_key else None)
 
-    if not jira_url or not project_key or not auth_token:
-        raise ValueError("Missing JIRA_URL, JIRA_PROJECT_KEY or JIRA_AUTH_TOKEN")
+    if not jira_url or not auth_token:
+        raise ValueError("Missing JIRA_URL or JIRA_AUTH_TOKEN")
+    if not jql:
+        raise ValueError("JQL query could not be determined")
 
-    jql = jql or f"project={project_key}"
-
-    issues = _fetch_issues(jira_url, project_key, auth_token, jql, max_results)
+    issues = _fetch_issues(jira_url, auth_token, jql, max_results)
     return [issue.model_dump(exclude={"labels"}) for issue in issues]
 
-
 class JiraRetriever:
-    """Compatibility wrapper for older code."""
+    """Backward compatible class-based API."""
 
     def __init__(self, url: str, username: str, token: str) -> None:
         self.base_url = url.rstrip("/")
@@ -173,11 +131,9 @@ class JiraRetriever:
             max_results=max_results,
         )
 
-
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=5), reraise=True)
 def _get(url: str, params: dict[str, str], token: str) -> dict:
-    """Backward-compatible request helper."""
-
+    """Legacy helper kept for compatibility."""
     headers = {
         "Authorization": f"Basic {token}",
         "Accept": "application/json",
@@ -186,9 +142,7 @@ def _get(url: str, params: dict[str, str], token: str) -> dict:
     resp.raise_for_status()
     return resp.json()
 
-
 if __name__ == "__main__":
-    # 4) Příklad použití: vypíše všechna issue jako JSON
-    all_issues = fetch_all_issues()
-    for issue in all_issues:
-        print(issue.json())
+    issues = get_roadmap_ideas()
+    for issue in issues:
+        print(issue)


### PR DESCRIPTION
## Summary
- enhance `jira_retriever` to read JQL from env variable `JIRA_JQL`
- allow `_jira_get` to accept auth token as positional argument and read config at call time
- keep backward compatible `fetch_all_issues` and `JiraRetriever` API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e868762048330b55721a7d1520fe6