### PR TITLE
Add feedback loop and finalize MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Create a `.env` file in the project root based on `.env.example` and set:
 
 ## 🚧 Milestone Plan (MVP)
 
-1. [ ] Create retrievers for documentation and JIRA
-2. [ ] Setup basic LangChain or custom orchestrator
-3. [ ] Connect reasoning via GPT-4o
-4. [ ] Implement deduplication check
-5. [ ] Generate 1–2 ideas and export to Markdown
-6. [ ] Add feedback loop for evaluation
+1. [x] Create retrievers for documentation and JIRA
+2. [x] Setup basic LangChain or custom orchestrator
+3. [x] Connect reasoning via GPT-4o
+4. [x] Implement deduplication check
+5. [x] Generate 1–2 ideas and export to Markdown
+6. [x] Add feedback loop for evaluation

--- a/feedback/collector.py
+++ b/feedback/collector.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict
+
+
+def collect_ratings(ideas: List[Dict]) -> None:
+    """Prompt the user to rate each idea and store the ratings."""
+
+    ratings = []
+    for idea in ideas:
+        title = idea.get("title", "Idea")
+        idea_id = idea.get("id")
+        while True:
+            try:
+                value = int(input(f"Rate idea '{title}' (1-5): "))
+                if 1 <= value <= 5:
+                    break
+            except ValueError:
+                pass
+            print("Please enter a number between 1 and 5.")
+        ratings.append({"id": idea_id, "rating": value})
+
+    os.makedirs("output", exist_ok=True)
+    with open("output/feedback.json", "w", encoding="utf-8") as f:
+        json.dump(ratings, f, ensure_ascii=False, indent=2)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -18,6 +18,7 @@ from deduplication.checker import DeduplicationChecker
 from ideas.composer import IdeaComposer
 from llm_modules.reasoning import ReasoningEngine
 from output.export import IdeaExporter
+from feedback.collector import collect_ratings
 from retrievers.jira_retriever import get_roadmap_ideas
 from retrievers.roadmap_retriever import retrieve_roadmap_documents
 
@@ -99,6 +100,8 @@ class AgentOrchestrator:
         # Export ideas in Markdown format as well
         markdown_items = [idea["markdown"] for idea in composed]
         self.exporter.export_markdown(markdown_items, "output/ideas.md")
+
+        collect_ratings(composed)
 
         return composed
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,24 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from feedback.collector import collect_ratings
+
+
+def test_collect_ratings_writes_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    inputs = iter(["5", "3"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    ideas = [
+        {"id": "1", "title": "Idea 1"},
+        {"id": "2", "title": "Idea 2"},
+    ]
+
+    collect_ratings(ideas)
+
+    fb_path = tmp_path / "output" / "feedback.json"
+    assert fb_path.exists()
+    data = json.loads(fb_path.read_text(encoding="utf-8"))
+    assert data == [{"id": "1", "rating": 5}, {"id": "2", "rating": 3}]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -42,6 +42,8 @@ def test_run_agent_with_mocks(tmp_path, monkeypatch):
     issues_mock = MagicMock(return_value=issues)
     analyze_mock = MagicMock(return_value=ideas)
 
+    rating_mock = MagicMock()
+
     def export_mock(items, path):
         # Write a simple file to emulate export
         with open(path, "w", encoding="utf-8") as f:
@@ -55,6 +57,7 @@ def test_run_agent_with_mocks(tmp_path, monkeypatch):
     monkeypatch.setattr(orchestrator, func, issues_mock)
     monkeypatch.setattr(orchestrator.ReasoningEngine, "analyze", analyze_mock)
     monkeypatch.setattr(orchestrator.IdeaExporter, "export_markdown", export_magic)
+    monkeypatch.setattr(orchestrator, "collect_ratings", rating_mock)
 
     agent = AgentOrchestrator(
         roadmap_url="http://example.com",
@@ -79,3 +82,4 @@ def test_run_agent_with_mocks(tmp_path, monkeypatch):
         data = json.load(f)
     assert data and data[0]["title"] == "New Idea"
     assert result[0]["title"] == "New Idea"
+    rating_mock.assert_called_once_with(result)


### PR DESCRIPTION
## Summary
- add `feedback.collector` for gathering ratings
- integrate rating collection into `AgentOrchestrator.run_agent`
- test rating collector and orchestrator integration
- update README MVP checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e8be2e38c833085158578e8dc13a6