### PR TITLE
Fix Jira query quoting

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -69,7 +69,8 @@ class AgentOrchestrator:
             jira_url=self.jira_url,
             project_key=self.jira_project_key,
             auth_token=self.jira_token,
-            jql=f"project={self.jira_project_key}",
+            # Quote project key to avoid 400 errors if the key contains digits or other characters
+            jql=f'project="{self.jira_project_key}"',
         )
         print(f"Fetched {len(jira_issues)} issues")
 


### PR DESCRIPTION
## Summary
- quote Jira project key in default JQL to avoid 400 errors
- ensure orchestrator uses quoted project key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e8ec1de988330890ab31a59f50c97