### PR TITLE
Add extensive logging to Jira retriever

### DIFF
--- a/retrievers/jira_retriever.py
+++ b/retrievers/jira_retriever.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 """Retrieve JIRA issues for the orchestrator."""
 
 import os
+import logging
 from typing import List, Optional
 
 import requests
@@ -16,6 +17,8 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 # Load environment variables from .env file
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 JIRA_URL = os.getenv("JIRA_URL")
 JIRA_PROJECT_KEY = os.getenv("JIRA_PROJECT_KEY")
 JIRA_AUTH_TOKEN = os.getenv("JIRA_AUTH_TOKEN")
@@ -24,6 +27,13 @@ JIRA_JQL = os.getenv("JIRA_JQL")
 
 if not JIRA_URL or not JIRA_AUTH_TOKEN:
     raise EnvironmentError("JIRA_URL and JIRA_AUTH_TOKEN must be set")
+
+logger.debug(
+    "Environment loaded JIRA_URL=%s JIRA_PROJECT_KEY=%s JIRA_JQL=%s",
+    JIRA_URL,
+    JIRA_PROJECT_KEY,
+    JIRA_JQL,
+)
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=5), reraise=True)
 def _jira_get(
@@ -43,9 +53,21 @@ def _jira_get(
         "Authorization": f"Basic {auth_token}",
         "Accept": "application/json",
     }
+
+    logger.debug(
+        "_jira_get called with endpoint=%s jira_url=%s params=%s",
+        endpoint,
+        jira_url,
+        params,
+    )
+    logger.debug("Request URL: %s", url)
+
     resp = requests.get(url, headers=headers, params=params, timeout=30)
+    logger.debug("Response status: %s", resp.status_code)
     resp.raise_for_status()
-    return resp.json()
+    data = resp.json()
+    logger.debug("Response JSON: %s", data)
+    return data
 
 class JiraIssue(BaseModel):
     key: str
@@ -57,24 +79,34 @@ class JiraIssue(BaseModel):
 def _fetch_issues(jira_url: str, auth_token: str, jql: str, max_results: int) -> List[JiraIssue]:
     """Fetch issues from JIRA using the given JQL query."""
 
-    endpoint = "rest/api/3/search"
+    endpoint = "rest/api/2/search"
     start_at = 0
     issues: List[JiraIssue] = []
 
+    logger.debug(
+        "Starting issue fetch with jql=%s max_results=%d",
+        jql,
+        max_results,
+    )
+
     while True:
+        logger.debug("Fetching page starting at %d", start_at)
         params = {
             "jql": jql,
             "startAt": start_at,
             "maxResults": max_results,
             "fields": "summary,description,status,labels",
         }
+        logger.debug("Request params: %s", params)
         try:
             data = _jira_get(endpoint, params, auth_token, jira_url=jira_url)
         except HTTPError as e:
-            print("JIRA Error response:", e.response.text)
+            logger.error("JIRA Error response: %s", e.response.text)
             raise
 
+        logger.debug("Received %d issues", len(data.get("issues", [])))
         for raw in data.get("issues", []):
+            logger.debug("Processing raw issue: %s", raw.get("key"))
             f = raw.get("fields", {})
             issues.append(
                 JiraIssue(
@@ -91,6 +123,7 @@ def _fetch_issues(jira_url: str, auth_token: str, jql: str, max_results: int) ->
         if start_at >= total:
             break
 
+    logger.debug("Total issues fetched: %d", len(issues))
     return issues
 
 def fetch_all_issues(project_key: str = JIRA_PROJECT_KEY, max_results: int = 50) -> List[JiraIssue]:
@@ -100,6 +133,11 @@ def fetch_all_issues(project_key: str = JIRA_PROJECT_KEY, max_results: int = 50)
         raise ValueError("Project key must be provided when JIRA_JQL is not used")
     # Quote the project key to avoid JQL syntax errors for non-alphanumeric keys
     jql = f'project="{project_key}"'
+    logger.debug(
+        "fetch_all_issues called with project_key=%s max_results=%d",
+        project_key,
+        max_results,
+    )
     return _fetch_issues(JIRA_URL, JIRA_AUTH_TOKEN, jql, max_results)
 
 def get_roadmap_ideas(
@@ -124,13 +162,23 @@ def get_roadmap_ideas(
     else:
         final_jql = None
 
+    logger.debug(
+        "get_roadmap_ideas called with jira_url=%s project_key=%s jql=%s max_results=%d",
+        jira_url,
+        project_key,
+        jql,
+        max_results,
+    )
+
     if not jira_url or not auth_token:
         raise ValueError("Missing JIRA_URL or JIRA_AUTH_TOKEN")
     if not final_jql:
         raise ValueError("JQL query could not be determined")
 
     issues = _fetch_issues(jira_url, auth_token, final_jql, max_results)
-    return [issue.model_dump(exclude={"labels"}) for issue in issues]
+    result = [issue.model_dump(exclude={"labels"}) for issue in issues]
+    logger.debug("Returning %d roadmap ideas", len(result))
+    return result
 
 class JiraRetriever:
     """Backward compatible class-based API."""
@@ -138,8 +186,18 @@ class JiraRetriever:
     def __init__(self, url: str, username: str, token: str) -> None:
         self.base_url = url.rstrip("/")
         self.token = token
+        logger.debug(
+            "Initialized JiraRetriever with base_url=%s username=%s",
+            self.base_url,
+            username,
+        )
 
     def fetch_issues(self, project_key: str, max_results: int = 50) -> List[dict]:
+        logger.debug(
+            "JiraRetriever.fetch_issues called with project_key=%s max_results=%d",
+            project_key,
+            max_results,
+        )
         return get_roadmap_ideas(
             jira_url=self.base_url,
             project_key=project_key,
@@ -154,11 +212,21 @@ def _get(url: str, params: dict[str, str], token: str) -> dict:
         "Authorization": f"Basic {token}",
         "Accept": "application/json",
     }
+    logger.debug(
+        "_get called with url=%s params=%s token_provided=%s",
+        url,
+        params,
+        bool(token),
+    )
     resp = requests.get(url, params=params, headers=headers, timeout=30)
+    logger.debug("Legacy _get response status: %s", resp.status_code)
     resp.raise_for_status()
-    return resp.json()
+    data = resp.json()
+    logger.debug("Legacy _get response JSON: %s", data)
+    return data
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     issues = get_roadmap_ideas()
     for issue in issues:
         print(issue)


### PR DESCRIPTION
## Summary
- log environment variables when Jira module loads
- add debug logging to `_jira_get`, `_fetch_issues`, `fetch_all_issues`, `get_roadmap_ideas`, and the `JiraRetriever` class
- log legacy `_get` calls and responses
- adjust search endpoint to `/rest/api/2/search`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685eae4ad9708330ba9b16f019890489